### PR TITLE
Added safety check for if UIViewController is being presented when trying to dismiss

### DIFF
--- a/FCOverlayViewControllerClass/FCOverlayViewController.m
+++ b/FCOverlayViewControllerClass/FCOverlayViewController.m
@@ -58,24 +58,26 @@
     
     if (self.viewControllerToPresent) {
         // present the view controller
-        [self presentViewController:self.viewControllerToPresent
-                           animated:self.showAnimated
-                         completion:^{
+		dispatch_async(dispatch_get_main_queue(), ^{
+			[self presentViewController:self.viewControllerToPresent
+					animated:self.showAnimated
+					completion:^{
 
-			if(self.completionBlock)
-			{
-				self.completionBlock();
-			}
-			
-			if(self.shouldDismissWhenReady)
-			{
-				[self dismissViewControllerAnimated:NO completion:nil];
-			}
+				if (self.completionBlock)
+				{
+					self.completionBlock();
+				}
 
-		}];
-        
-        // make sure we never present the view controller again (for example after it is dismissed)
-        self.viewControllerToPresent = nil;
+				if (self.shouldDismissWhenReady)
+				{
+					[self dismissViewControllerAnimated:NO completion:nil];
+				}
+
+			}];
+
+			// make sure we never present the view controller again (for example after it is dismissed)
+			self.viewControllerToPresent = nil;
+		});
     }
 }
 


### PR DESCRIPTION
I noticed that if the I use FCOverlay to present a loading view will performing a network request and the request finishes and dismiss is called while the viewcontroller is being presented then the viewcontroller does not get dismissed. I have added a fix for this.
