### PR TITLE
Fixed issue when trying to dismiss viewcontroller before it was being presented

### DIFF
--- a/FCOverlayViewControllerClass/FCOverlayViewController.m
+++ b/FCOverlayViewControllerClass/FCOverlayViewController.m
@@ -152,9 +152,10 @@
 // dismiss the overlay controller and corresponding window
 - (void)dismissViewControllerAnimated:(BOOL)flag completion:(void (^)(void))completion
 {
+	self.shouldDismissWhenReady = YES;
+
 	if(self.presentedViewController && self.presentedViewController.isBeingPresented)
 	{
-		self.shouldDismissWhenReady = YES;
 		return;
 	}
 
@@ -192,6 +193,8 @@
             // dequeue the next queued overlay
             [FCOverlay dequeue];
         }
+
+		self.shouldDismissWhenReady = NO;
         
         // call completion block
         if (completion) completion();


### PR DESCRIPTION
There was an issue with a viewcontroller being dismissed before it had started to present. Improved this fix.
